### PR TITLE
[T30] production 依存関係を更新（Next.js を除く）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "classmethod-pricing-chart",
       "version": "0.1.1",
       "dependencies": {
-        "chart.js": "4.4.7",
+        "chart.js": "4.5.1",
         "next": "15.5.4",
-        "papaparse": "5.4.1",
-        "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "papaparse": "5.5.3",
+        "react": "19.2.5",
+        "react-dom": "19.2.5"
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.14",
@@ -1839,9 +1839,9 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.7.tgz",
-      "integrity": "sha512-pwkcKfdzTMAU/+jNosKhNL2bHtJc/sSmYgVbuGTEDhzkrhmyihmP7vUc/5ZK9WopidMDHNe3Wm7jOd/WhuHWuw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
@@ -2483,9 +2483,9 @@
       "license": "MIT"
     },
     "node_modules/papaparse": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
-      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
       "license": "MIT"
     },
     "node_modules/path-key": {
@@ -2554,24 +2554,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.2.5"
       }
     },
     "node_modules/rolldown": {
@@ -2609,9 +2609,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "chart.js": "4.4.7",
+    "chart.js": "4.5.1",
     "next": "15.5.4",
-    "papaparse": "5.4.1",
-    "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "papaparse": "5.5.3",
+    "react": "19.2.5",
+    "react-dom": "19.2.5"
   },
   "devDependencies": {
     "@types/papaparse": "5.3.16",


### PR DESCRIPTION
## 概要

Dependabot PR #12 に含まれていた production 依存関係のうち、Next.js 以外を更新。
Next.js 15→16 はメジャーアップグレードのため #34 (T31) で別途対応する。

## 変更内容

| パッケージ | 変更前 | 変更後 |
|-----------|--------|--------|
| `chart.js` | 4.4.7 | 4.5.1 |
| `papaparse` | 5.4.1 | 5.5.3 |
| `react` | 19.1.0 | 19.2.5 |
| `react-dom` | 19.1.0 | 19.2.5 |

## セキュリティ

`npm audit` で 1 moderate + 1 critical が報告されているが、これらは既存の `next@15.5.4` 起因であり本 PR の変更とは無関係。T31 での Next.js アップグレードにより解消予定。

## 関連 Issue

closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)