### PR TITLE
[T33] chart.js 4.5.1 の型変更に対応（chartRef の型を修正）

### DIFF
--- a/src/components/StackedBarChart.tsx
+++ b/src/components/StackedBarChart.tsx
@@ -35,7 +35,7 @@ export default function StackedBarChart({
   sumPosition?: "top" | "bottom";
 }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const chartRef = useRef<ChartJS | null>(null);
+  const chartRef = useRef<ChartJS<"bar"> | null>(null);
 
   const colors = useMemo(
     () => services.map((_, index) => generateColor(index)),


### PR DESCRIPTION
## 概要

chart.js 4.4.7 → 4.5.1 アップデート（PR #35）により `develop` の CI ビルドが失敗していたため修正する。

## 原因

chart.js 4.5.1 で型の variance が変更され、`Chart<"bar", number[], string>` が汎用の `Chart<keyof ChartTypeRegistry, ...>` に代入できなくなった。

## 変更内容

`src/components/StackedBarChart.tsx` の `chartRef` の型を実際の用途に合わせて絞る。

```typescript
// 変更前
const chartRef = useRef<ChartJS | null>(null);

// 変更後
const chartRef = useRef<ChartJS<"bar"> | null>(null);
```

## 関連

closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)