### PR TITLE
[T35] アップロードファイル件数カウンターのラベル修正

### DIFF
--- a/src/components/UploadPanel.tsx
+++ b/src/components/UploadPanel.tsx
@@ -92,7 +92,7 @@ export default function UploadPanel({
         )}
         {sortedMonths.length > 0 && (
           <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
-            <span>{sortedMonths.length} 件の月次レポートを表示中</span>
+            <span>{sortedMonths.length} ヶ月分のデータを表示中</span>
             <button
               type="button"
               onClick={onClearReports}


### PR DESCRIPTION
## Summary

- `UploadPanel.tsx` のカウンター表示を「○件の月次レポートを表示中」→「○ヶ月分のデータを表示中」に変更
- ファイル数と誤読されやすいラベルを、実態（取り込み済みの月数）が明確に伝わる表現に修正

## 関連 Issue

Closes #42

## Test plan

- [ ] 正規 CSV を 1 件アップロード → 「1 ヶ月分のデータを表示中」と表示される
- [ ] 正規 CSV を 2 件（別月）同時アップロード → 「2 ヶ月分のデータを表示中」と表示される
- [ ] 同一月・別アカウントのファイルを追加アップロード → 月数は増えず「2 ヶ月分のデータを表示中」のまま
- [ ] 「クリア」ボタンクリック → カウンターが消え初期状態に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)